### PR TITLE
Default SecurityIdentityAugmentor priority to 0

### DIFF
--- a/src/main/java/io/quarkus/security/identity/SecurityIdentityAugmentor.java
+++ b/src/main/java/io/quarkus/security/identity/SecurityIdentityAugmentor.java
@@ -15,7 +15,9 @@ public interface SecurityIdentityAugmentor {
     /**
      * @return The priority
      */
-    int priority();
+    default int priority() {
+        return 0;
+    }
 
     /**
      * Augments a security identity to allow for modification of the underlying identity.


### PR DESCRIPTION
The idea is to simplify the majority of the custom `SecurityIdentityAugmentor` implementations which have to implement the priority method when only a single `SecurityIdentityAugmentor` implementation is provided.
It does not break the user code. Quarkus Security documentation will be updated to let the users know that registering multiple `SecurityIdentityAugmentor`s may require implementing this method but only if the ordering is important   