### PR TITLE
Add AuthenticationRedirectException and AuthenticationCompletionException

### DIFF
--- a/src/main/java/io/quarkus/security/AuthenticationCompletionException.java
+++ b/src/main/java/io/quarkus/security/AuthenticationCompletionException.java
@@ -1,0 +1,27 @@
+package io.quarkus.security;
+
+/**
+ * Exception indicating that a user authentication flow has failed and no challenge is required.
+ *
+ * For example, it can be used to avoid the redirect loops during an OpenId Connect authorization code flow
+ * after the user has already authenticated at the IDP site but a state parameter is not available after
+ * a redirect back to the Quarkus endpoint or if the code flow can not be completed for some other reasons.
+ */
+public class AuthenticationCompletionException extends RuntimeException {
+
+    public AuthenticationCompletionException() {
+
+    }
+
+    public AuthenticationCompletionException(String errorMessage) {
+        this(errorMessage, null);
+    }
+
+    public AuthenticationCompletionException(Throwable cause) {
+        this(null, cause);
+    }
+
+    public AuthenticationCompletionException(String errorMessage, Throwable cause) {
+        super(errorMessage, cause);
+    }
+}

--- a/src/main/java/io/quarkus/security/AuthenticationRedirectException.java
+++ b/src/main/java/io/quarkus/security/AuthenticationRedirectException.java
@@ -1,0 +1,30 @@
+package io.quarkus.security;
+
+/**
+ * Exception indicating that a redirect is required for the authentication flow to complete.
+ *
+ * For example, it can be used during an OpenId Connect authorization code flow to redirect
+ * the user to the original request URI which was used before the authorization code flow has started.
+ */
+public class AuthenticationRedirectException extends RuntimeException {
+
+    final int code;
+    final String redirectUri;
+
+    public AuthenticationRedirectException(String redirectUri) {
+        this(302, redirectUri);
+    }
+
+    public AuthenticationRedirectException(int code, String redirectUri) {
+        this.code = code;
+        this.redirectUri = redirectUri;
+    }
+
+    public int getCode() {
+        return this.code;
+    }
+
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+}


### PR DESCRIPTION
This is needed to make the OIDC code flow to work with the `proactive-auth` disabled, but also it makes sense to keep all the security related exceptions in one place