### PR TITLE
Add context attributes to the AuthenticationRequest interface

### DIFF
--- a/src/main/java/io/quarkus/security/identity/request/AnonymousAuthenticationRequest.java
+++ b/src/main/java/io/quarkus/security/identity/request/AnonymousAuthenticationRequest.java
@@ -3,7 +3,7 @@ package io.quarkus.security.identity.request;
 /**
  * A request the for the Anonymous identity
  */
-public final class AnonymousAuthenticationRequest implements AuthenticationRequest {
+public final class AnonymousAuthenticationRequest extends BaseAuthenticationRequest implements AuthenticationRequest {
 
     public static final AnonymousAuthenticationRequest INSTANCE = new AnonymousAuthenticationRequest();
 

--- a/src/main/java/io/quarkus/security/identity/request/AuthenticationRequest.java
+++ b/src/main/java/io/quarkus/security/identity/request/AuthenticationRequest.java
@@ -1,11 +1,13 @@
 package io.quarkus.security.identity.request;
 
+import java.util.Map;
+
 import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 
 /**
- * A marker interface that represents a request for an authenticated identity.
+ * Represents a request for an authenticated identity.
  * <p>
  * Different {@link IdentityProvider} implementations will be able to handle different
  * types of request.
@@ -14,9 +16,49 @@ import io.quarkus.security.identity.SecurityIdentity;
  * providers, while still allowing for a single API to get an authenticated
  * {@link SecurityIdentity}.
  * <p>
+ * <p>
+ * Attributes can be used to transport additional context information with the request such as context path,
+ * http header or query parameter values. Attributes may also be enriched or verified by a central component before the request
+ * arrives at the {@link IdentityProvider}.
+ * </p>
  * Note that identity providers can only handle a single request type, and when a
  * request type is registered with the {@link IdentityProviderManager} inheritance
  * is not taken into account.
  */
 public interface AuthenticationRequest {
+
+    /**
+     * Gets an attribute from the authentication request.
+     * <p>
+     * These can be arbitrary, and extensions are encouraged to use name spaced attribute names in a similar
+     * manner to package names.
+     * <p>
+     * The `quarkus.` namespace is reserved
+     * <p>
+     *
+     * @param name The attribute name
+     * @param <T>  The type of the attribute
+     * @return The attribute value
+     */
+    <T> T getAttribute(String name);
+
+    /**
+     * Sets an attribute on the authentication request.
+     * <p>
+     * These can be arbitrary, and extensions are encouraged to use name spaced attribute names in a similar
+     * manner to package names.
+     * <p>
+     * The `quarkus.` namespace is reserved
+     * <p>
+     *
+     * @param name The attribute name
+     * @param value The attribute value
+     */
+    void setAttribute(String name, Object value);
+
+    /**
+     * @return All the authentication request attributes. Modifications on the returned map will affect the authentication
+     * request attributes.
+     */
+    Map<String, Object> getAttributes();
 }

--- a/src/main/java/io/quarkus/security/identity/request/BaseAuthenticationRequest.java
+++ b/src/main/java/io/quarkus/security/identity/request/BaseAuthenticationRequest.java
@@ -1,0 +1,34 @@
+package io.quarkus.security.identity.request;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base implementation of the {@link AuthenticationRequest} interface for convenience.
+ */
+public abstract class BaseAuthenticationRequest implements AuthenticationRequest {
+
+    private Map<String, Object> attributes;
+
+    private Map<String, Object> attributes() {
+        if (attributes == null) {
+            attributes = new HashMap<>();
+        }
+        return attributes;
+    }
+
+    @Override
+    public <T> T getAttribute(String name) {
+        return attributes != null ? ((T) attributes.get(name)) : null;
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+        attributes().put(name, value);
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes();
+    }
+}

--- a/src/main/java/io/quarkus/security/identity/request/CertificateAuthenticationRequest.java
+++ b/src/main/java/io/quarkus/security/identity/request/CertificateAuthenticationRequest.java
@@ -1,13 +1,11 @@
 package io.quarkus.security.identity.request;
 
-import java.security.cert.X509Certificate;
-
 import io.quarkus.security.credential.CertificateCredential;
 
 /**
  * A {@link AuthenticationRequest} to authenticate from a {@link CertificateCredential}, such as when authenticating clients through TLS
  */
-public class CertificateAuthenticationRequest implements AuthenticationRequest {
+public class CertificateAuthenticationRequest extends BaseAuthenticationRequest implements AuthenticationRequest {
 
     private final CertificateCredential certificate;
 

--- a/src/main/java/io/quarkus/security/identity/request/TokenAuthenticationRequest.java
+++ b/src/main/java/io/quarkus/security/identity/request/TokenAuthenticationRequest.java
@@ -5,7 +5,7 @@ import io.quarkus.security.credential.TokenCredential;
 /**
  * An simple authentication request that uses a token
  */
-public class TokenAuthenticationRequest implements AuthenticationRequest {
+public class TokenAuthenticationRequest extends BaseAuthenticationRequest implements AuthenticationRequest {
 
     private final TokenCredential token;
 

--- a/src/main/java/io/quarkus/security/identity/request/TrustedAuthenticationRequest.java
+++ b/src/main/java/io/quarkus/security/identity/request/TrustedAuthenticationRequest.java
@@ -4,7 +4,7 @@ package io.quarkus.security.identity.request;
 /**
  * A request to authenticate from a trusted source, such as an encrypted cookie
  */
-public class TrustedAuthenticationRequest implements AuthenticationRequest {
+public class TrustedAuthenticationRequest extends BaseAuthenticationRequest implements AuthenticationRequest {
 
     private final String principal;
 

--- a/src/main/java/io/quarkus/security/identity/request/UsernamePasswordAuthenticationRequest.java
+++ b/src/main/java/io/quarkus/security/identity/request/UsernamePasswordAuthenticationRequest.java
@@ -5,7 +5,7 @@ import io.quarkus.security.credential.PasswordCredential;
 /**
  * An simple authentication request that uses a username and password
  */
-public class UsernamePasswordAuthenticationRequest implements AuthenticationRequest {
+public class UsernamePasswordAuthenticationRequest extends BaseAuthenticationRequest implements AuthenticationRequest {
 
     private final String username;
     private final PasswordCredential password;


### PR DESCRIPTION
Fix #12
This PR adds context attributes to the AuthenticationRequest interface. The attributes are designed similar to those defined on the SecurityIdentity interface. Since AuthenticationRequests are used to transport information and short lived I don't see a problem making the attributes mutable. If the attributes were immutable, the whole object would have to be copied in order to add an attribute after the AuthenticationRequests has been created.