### PR TITLE
Add explicit automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,21 @@
         </repository>
     </distributionManagement>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.quarkus.security.api</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>release</id>


### PR DESCRIPTION
Adds an explicit automatic module name of `io.quarkus.security`, which matches the root package name.

This is a breaking change for modular applications, but not for users that use Quarkus on the class path.

Fixes quarkusio/quarkus#25795
Fixes quarkusio/quarkus#40417

See also: https://github.com/quarkusio/quarkus/pull/29370