### PR TITLE
Introduce marker AuthenticationException as optimalization tool

### DIFF
--- a/src/main/java/io/quarkus/security/AuthenticationCompletionException.java
+++ b/src/main/java/io/quarkus/security/AuthenticationCompletionException.java
@@ -7,7 +7,7 @@ package io.quarkus.security;
  * after the user has already authenticated at the IDP site but a state parameter is not available after
  * a redirect back to the Quarkus endpoint or if the code flow can not be completed for some other reasons.
  */
-public class AuthenticationCompletionException extends RuntimeException {
+public class AuthenticationCompletionException extends RuntimeException implements AuthenticationException {
 
     public AuthenticationCompletionException() {
 

--- a/src/main/java/io/quarkus/security/AuthenticationException.java
+++ b/src/main/java/io/quarkus/security/AuthenticationException.java
@@ -1,0 +1,7 @@
+package io.quarkus.security;
+
+/**
+ * Purely marker interface for Quarkus Security Authentication exceptions.
+ */
+public interface AuthenticationException {
+}

--- a/src/main/java/io/quarkus/security/AuthenticationFailedException.java
+++ b/src/main/java/io/quarkus/security/AuthenticationFailedException.java
@@ -10,7 +10,7 @@ import io.quarkus.security.identity.IdentityProvider;
  * This can be used by a mechanism to determine if an authentication failure was
  * due to bad credentials vs some other form of internal failure.
  */
-public final class AuthenticationFailedException extends SecurityException {
+public final class AuthenticationFailedException extends SecurityException implements AuthenticationException {
     public AuthenticationFailedException() {
 
     }

--- a/src/main/java/io/quarkus/security/AuthenticationRedirectException.java
+++ b/src/main/java/io/quarkus/security/AuthenticationRedirectException.java
@@ -6,7 +6,7 @@ package io.quarkus.security;
  * For example, it can be used during an OpenId Connect authorization code flow to redirect
  * the user to the original request URI which was used before the authorization code flow has started.
  */
-public class AuthenticationRedirectException extends RuntimeException {
+public class AuthenticationRedirectException extends RuntimeException implements AuthenticationException {
 
     final int code;
     final String redirectUri;


### PR DESCRIPTION
Make `AuthenticationFailedException`, `AuthenticationRedirectException` and `AuthenticationCompletionException` inherit same predecessor, so that we can simplify and optimize instanceof conditions for Quarkus Authentication exceptions: https://github.com/quarkusio/quarkus/blob/main/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java#L257, https://github.com/quarkusio/quarkus/blob/main/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyStandaloneRecorder.java#L129, https://github.com/quarkusio/quarkus/blob/main/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java

The exceptions can't extend same class as `AuthenticationFailedException` extends `SecurityException` while `AuthenticationRedirectException` and `AuthenticationCompletionException` do not, therefore common predecessor is interface.