### PR TITLE
Add AuthenticationRequest attributes to AuthenticationRequestContext so that users can access RoutingContext

### DIFF
--- a/src/main/java/io/quarkus/security/identity/SecurityIdentityAugmentor.java
+++ b/src/main/java/io/quarkus/security/identity/SecurityIdentityAugmentor.java
@@ -2,6 +2,8 @@ package io.quarkus.security.identity;
 
 import io.smallrye.mutiny.Uni;
 
+import java.util.Map;
+
 /**
  * An interface that allows for a {@link SecurityIdentity} to be modified after creation.
  * <p>
@@ -26,4 +28,17 @@ public interface SecurityIdentityAugmentor {
      * @return A completion stage that will resolve to the modified identity
      */
     Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context);
+
+
+    /**
+     * Augments a security identity to allow for modification of the underlying identity.
+     *
+     * @param identity The identity
+     * @param context A context object that can be used to run blocking tasks
+     * @param attributes All the authentication request attributes
+     * @return A completion stage that will resolve to the modified identity
+     */
+    default Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context, Map<String, Object> attributes) {
+        return augment(identity, context);
+    }
 }


### PR DESCRIPTION
We add `RoutingContext` to authentication request attributes

https://github.com/quarkusio/quarkus/blob/main/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityUtils.java#L14

which makes it possible for users to access `RoutingContext` when proactive auth is enabled. There are issues opened related to `RoutingContext` in augmentor

- https://github.com/quarkusio/quarkus/issues/37457
- https://github.com/quarkusio/quarkus/issues/28326
- we have seen other requests to make `RoutingContext` accessible from the `SecurityIdentityAugmentor` like in https://github.com/quarkusio/quarkus/issues/16861
- (headers -> RoutingContext) https://github.com/quarkusio/quarkus/issues/37945

I've tried to explore passing the context via duplicated context local data https://github.com/quarkusio/quarkus/pull/37795 but from comments you can see there are performance arguments against it. We already have this map with the `RoutingContext`, so now I propose to add authentication attributes to the authentication request context.