### PR TITLE
Revert "Change artifact id to 'quarkus-security-api'"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-Quarkus Security API
-====================
+Quarkus Security
+================
 
-[![Version](https://img.shields.io/maven-central/v/io.quarkus.security/quarkus-security-api?logo=apache&style=for-the-badge)](https://search.maven.org/artifact/io.quarkus.security/quarkus-security-api)
+[![Version](https://img.shields.io/maven-central/v/io.quarkus.security/quarkus-security?logo=apache&style=for-the-badge)](https://search.maven.org/artifact/io.quarkus.security/quarkus-security)
 
-The Quarkus core security API.
+The Quarkus core security implementation.
 
 ## Release
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <groupId>io.quarkus.security</groupId>
-    <artifactId>quarkus-security-api</artifactId>
+    <artifactId>quarkus-security</artifactId>
     <version>2.0.4-SNAPSHOT</version>
 
     <properties>


### PR DESCRIPTION
This reverts commit e276de8abc3992b5bcb49266bce53f7772744889.

@sberyozkin we could discuss changing the artifact id in the future but it will require a major version bump + making sure that all potential consumers are aware of the change.

Not sure if it's worth it given I think adjusting the module name will be good enough for now.