### PR TITLE
Add typed 'getPrincipal' method to the SecurityIdentity for user convenience

### DIFF
--- a/src/main/java/io/quarkus/security/identity/SecurityIdentity.java
+++ b/src/main/java/io/quarkus/security/identity/SecurityIdentity.java
@@ -31,6 +31,14 @@ public interface SecurityIdentity {
     Principal getPrincipal();
 
     /**
+     * @param clazz {@link Principal} subclass
+     * @return the {@link Principal} subclass representing the current user.
+     */
+    default <T extends Principal> T getPrincipal(Class<T> clazz) {
+        return clazz.cast(getPrincipal());
+    }
+
+    /**
      * @return <code>true</code> if this identity represents an anonymous (i.e. not logged in) user
      */
     boolean isAnonymous();


### PR DESCRIPTION
- Closes: https://github.com/quarkusio/quarkus-security/issues/33

Personally, I'd prefer `<T extends Principal> T getPrincipal()` but it would be breaking change.