### PR TITLE
Update SecurityIdentity to list owned Permissions and allow simpler permission checks

### DIFF
--- a/src/main/java/io/quarkus/security/identity/SecurityIdentity.java
+++ b/src/main/java/io/quarkus/security/identity/SecurityIdentity.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
+import io.quarkus.security.StringPermission;
 import io.quarkus.security.credential.Credential;
 import io.smallrye.mutiny.Uni;
 
@@ -62,15 +63,20 @@ public interface SecurityIdentity {
 
     /**
      * Checks if a user has a given role. These roles must be resolvable in advance for every request.
-     * <p>
-     * If more advanced authorization support is required than can be provided by a simple role based system
-     * then {@link #checkPermission(Permission)} and {@link #checkPermissionBlocking(Permission)} should be used
-     * instead.
-     * <p>
      *
      * @return <code>true</code> if the identity has the specified role.
      */
     boolean hasRole(String role);
+
+    /**
+     * Returns the set of all permissions held by the user. These permissions must be resolvable in advance for every request.
+     * <p>
+     * This set should either be unmodifiable, or a defensive copy so attempts to change the role set do not modify
+     * the underlying identity.
+     *
+     * @return The set of all permissions held by the user
+     */
+    Set<Permission> getPermissions();
 
     /**
      * Gets the users credential of the given type, or <code>null</code> if a credential of the given type is not
@@ -111,7 +117,7 @@ public interface SecurityIdentity {
     Map<String, Object> getAttributes();
 
     /**
-     * Checks if a user holds a given permissions, and if so will return <code>true</code>.
+     * Checks if a user holds a given permission.
      * <p>
      * This method is asynchronous, as it may involve calls to a remote resource.
      *
@@ -121,7 +127,7 @@ public interface SecurityIdentity {
     Uni<Boolean> checkPermission(Permission permission);
 
     /**
-     * Checks if a user holds a given permissions, and if so will return <code>true</code>.
+     * Checks if a user holds a given permission.
      * <p>
      * This method is a blocking version of {@link #checkPermission(Permission)}. By default it will
      * just wait for the {@link CompletionStage} to be complete, however it is likely that some implementations
@@ -131,6 +137,32 @@ public interface SecurityIdentity {
      * @return A completion stage that will resolve to true if the user has the specified permission
      */
     default boolean checkPermissionBlocking(Permission permission) {
+        return checkPermission(permission).await().indefinitely();
+    }
+
+    /**
+     * Checks if a user holds a given permission.
+     * <p>
+     * This method is asynchronous, as it may involve calls to a remote resource.
+     *
+     * @param permission The permission
+     * @return A completion stage that will resolve to true if the user has the specified permission
+     */
+    default Uni<Boolean> checkPermission(String permission) {
+    	return checkPermission(new StringPermission(permission));
+    }
+
+    /**
+     * Checks if a user holds a given permission.
+     * <p>
+     * This method is a blocking version of {@link #checkPermission(Permission)}. By default it will
+     * just wait for the {@link CompletionStage} to be complete, however it is likely that some implementations
+     * will want to provide a more efficient version.
+     *
+     * @param permission The permission
+     * @return A completion stage that will resolve to true if the user has the specified permission
+     */
+    default boolean checkPermissionBlocking(String permission) {
         return checkPermission(permission).await().indefinitely();
     }
 }


### PR DESCRIPTION
The main purpose of this PR is to make it possible to simplify the  way `@PermissionAllowed` are enforced by default at the Quarkus level. 

At the Quarkus level, when no (recently introduced) `@PermissionChecker` is used, the only way for users to have `@PermissionAllowed` checks enforced is basically do these checks themselves by registering a custom `SecurityidentityAugmentor` and adding a custom permission checker function:

For example (from the Quarkus docs):
```
@ApplicationScoped
public class PermissionsIdentityAugmentor implements SecurityIdentityAugmentor {

    @Override
    public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
    //...
        Permission possessedPermission = new MediaLibraryPermission("media-library",
                new String[] { "read", "write", "list"}); 
        return QuarkusSecurityIdentity.builder(identity)
                .addPermissionChecker(new Function<Permission, Uni<Boolean>>() { 
                    @Override
                    public Uni<Boolean> apply(Permission requiredPermission) {
                        boolean accessGranted = possessedPermission.implies(requiredPermission);
                        return Uni.createFrom().item(accessGranted);
                    }
                })
                .build();
       };
}
```

Where the users need to correctly write the permission checker function making sure it is permission which is meant to be associated with the identity is used to call `implies` , not the required one... And there is no way to check on `SecurityIdentity` which permissions it owns.

 @FroMage and @michalvavrik worked out a plan to make it easier to implement such functions, but IMHO users should be totally shielded from having to write such checkers. We do not ask users to manually write role checks, and we should not ask them to do it for permissions. They can do if they really want to, but it should be avoidable.

The above code should look like this:

```
@ApplicationScoped
public class PermissionsIdentityAugmentor implements SecurityIdentityAugmentor {

    @Override
    public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
        return QuarkusSecurityIdentity.builder(identity)
                .addPermission(new MediaLibraryPermission("media-library", new String[] { "read", "write", "list"});)
                .build();
       };
}
```

And Quarkus Security will do the required checks itself, by checking `SecurityIdentity#getPermissions()` added in this PR.

You link to `SecurityIdentity#checkPermission` is about users writing the code, while I'd like users not to write any checker code at all, all the users should be worried about is associating permissions that the identity is supposed to own with this identity