### PR TITLE
Improve JavaDocs of some API classes

### DIFF
--- a/src/main/java/io/quarkus/security/PermissionChecker.java
+++ b/src/main/java/io/quarkus/security/PermissionChecker.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation that can be used to annotate a CDI bean method that checks
- * if a {@link io.quarkus.security.identity.SecurityIdentity} holds a permission specified by the {@link #value()}.
+ * if a matching {@link PermissionsAllowed} permission with the {@link #value()} name can be granted.
  * For example:
  * <pre>
  * {@code
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * }
  * }
  * </pre>
- * The permission checker methods can include any of secured method parameters (matched by name).
+ * The permission checker methods can include any of the secured method parameters, matched by name.
  * Consider the following secured method:
  * <pre>
  * {@code
@@ -37,8 +37,8 @@ import java.lang.annotation.Target;
  * }
  * }
  * </pre>
- * The permission checker that grants access to the {@code updateString} method can inject
- * any arguments it requires and optionally even {@link io.quarkus.security.identity.SecurityIdentity}:
+ * The permission checker that grants access to the {@code updateString} method can include
+ * any of the {@code updateString} method parameters, {@link io.quarkus.security.identity.SecurityIdentity} can also be included:
  * <pre>
  * {@code
  * &#64;PermissionChecker("update")
@@ -47,8 +47,34 @@ import java.lang.annotation.Target;
  * }
  * }
  * </pre>
- * The permission checker method parameters are matched with the secured method parameters in exactly same fashion
- * as are constructor parameters of a custom permission. Please see {@link PermissionsAllowed#params()} for more information.
+ * The permission checker method parameters are matched with the secured method parameters exactly the same way as
+ * the constructor parameters of a custom permission are. Please see {@link PermissionsAllowed#params()} for more information.
+ * <pre>
+ * If the {@link PermissionsAllowed} annotation lists several permission names and its {@link PermissionsAllowed#inclusive} property is set to `true` then an equal number of permission checker methods must be available.
+ * Consider the following secured method:
+ * <pre>
+ * {@code
+ * &#64;PermissionsAllowed(value={"read:all", "write"}, inclusive=true)
+ * public String readWriteString(String a) {
+ *     ...
+ * }
+ * }
+ * </pre>
+ * For the access to the {@code readWriteString} method be granted, two permission checkers,
+ * one for the `read:all` permission, and another one for the `write` permission, must be available:
+ * <pre>
+ * {@code
+ * &#64;PermissionChecker("read:all")
+ * public boolean canRead(SecurityIdentity identity) {
+ *     ...
+ * }
+ * &#64;PermissionChecker("write")
+ * public boolean canWrite(SecurityIdentity identity) {
+ *     ...
+ * }
+ * }
+ * </pre>
+ * Note that a permission checker matches one of the {@link PermissionsAllowed} permissions if their String names are equal.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/io/quarkus/security/identity/SecurityIdentity.java
+++ b/src/main/java/io/quarkus/security/identity/SecurityIdentity.java
@@ -4,51 +4,49 @@ import java.security.Permission;
 import java.security.Principal;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
 
 import io.quarkus.security.credential.Credential;
 import io.smallrye.mutiny.Uni;
 
 /**
- * Interface that represents the currently logged in user.
+ * Interface that represents the current security identity such as a logged-in user or other authenticated subject.
  * <p>
- * Instances of this class will always be available for injection even if no user is currently
- * logged in. In this case {@link #isAnonymous()} will return <code>true</code>, and the user
- * will generally not have any roles (although some implementation may assign roles to anonymous users).
+ * Instances of this class will always be available for injection even if no authentication has taken place.
+ * In this case {@link #isAnonymous()} will return <code>true</code>, and the security identity will generally have no roles.
  * <p>
  * Implementations should be immutable.
  */
 public interface SecurityIdentity {
 
     /**
-     * The attribute name that is used to store the underlying user representation.
+     * The attribute name that is used to store the underlying security identity representation.
      */
     String USER_ATTRIBUTE = "quarkus.user";
 
     /**
-     * @return the {@link Principal} representing the current user.
+     * @return the {@link Principal} representing the current security identity.
      */
     Principal getPrincipal();
 
     /**
      * @param clazz {@link Principal} subclass
-     * @return the {@link Principal} subclass representing the current user.
+     * @return the {@link Principal} subclass representing the current security identity.
      */
     default <T extends Principal> T getPrincipal(Class<T> clazz) {
         return clazz.cast(getPrincipal());
     }
 
     /**
-     * @return <code>true</code> if this identity represents an anonymous (i.e. not logged in) user
+     * @return <code>true</code> if this identity is anonymous
      */
     boolean isAnonymous();
 
     /**
-     * Returns the set of all roles held by the user. These roles must be resolvable in advance for every request.
+     * Returns the set of all roles held by the security identity. These roles must be resolvable in advance for every request.
      * <p>
      * Note that roles are returned on a best effort basis. To actually check if
      * a user holds a role {@link #hasRole(String)} should be used instead. Some API's (e.g. JAX-RS) do not allow
-     * for all roles to be returned, so if the underlying user representation does not support retrieving all the roles
+     * for all roles to be returned, so if the underlying identity representation does not support retrieving all the roles
      * this method will not always be reliable. In general all built in Quarkus security extensions should provide this,
      * unless it is documented otherwise.
      *
@@ -61,7 +59,7 @@ public interface SecurityIdentity {
     Set<String> getRoles();
 
     /**
-     * Checks if a user has a given role. These roles must be resolvable in advance for every request.
+     * Checks if a security identity has a given role. These roles must be resolvable in advance for every request.
      * <p>
      * If more advanced authorization support is required than can be provided by a simple role based system
      * then {@link #checkPermission(Permission)} and {@link #checkPermissionBlocking(Permission)} should be used
@@ -73,7 +71,7 @@ public interface SecurityIdentity {
     boolean hasRole(String role);
 
     /**
-     * Gets the users credential of the given type, or <code>null</code> if a credential of the given type is not
+     * Gets the security identity credential of the given type, or <code>null</code> if a credential of the given type is not
      * present.
      *
      * @param credentialType The type of the credential
@@ -83,7 +81,7 @@ public interface SecurityIdentity {
     <T extends Credential> T getCredential(Class<T> credentialType);
 
     /**
-     * Returns a set of all credentials owned by this user.
+     * Returns a set of all credentials owned by this security identity.
      *
      * @return a set of all credentials
      */
@@ -111,24 +109,22 @@ public interface SecurityIdentity {
     Map<String, Object> getAttributes();
 
     /**
-     * Checks if a user holds a given permissions, and if so will return <code>true</code>.
+     * Checks if a security identity holds a given permission.
      * <p>
      * This method is asynchronous, as it may involve calls to a remote resource.
      *
      * @param permission The permission
-     * @return A completion stage that will resolve to true if the user has the specified permission
+     * @return Uni that will resolve to true if the security identity has the specified permission
      */
     Uni<Boolean> checkPermission(Permission permission);
 
     /**
-     * Checks if a user holds a given permissions, and if so will return <code>true</code>.
+     * Checks if a user holds a given permission.
      * <p>
-     * This method is a blocking version of {@link #checkPermission(Permission)}. By default it will
-     * just wait for the {@link CompletionStage} to be complete, however it is likely that some implementations
-     * will want to provide a more efficient version.
+     * This method is a blocking version of {@link #checkPermission(Permission)}..
      *
      * @param permission The permission
-     * @return A completion stage that will resolve to true if the user has the specified permission
+     * @return true if the security identity has the specified permission
      */
     default boolean checkPermissionBlocking(Permission permission) {
         return checkPermission(permission).await().indefinitely();


### PR DESCRIPTION
I've worked on some minor JavaDocs polishing for the following classes:
* `SecurityIdentity` - replaced references to the `user` with the `security identity` as there could be no any logged-in user behind the current authenticated request; some other minor cleanup
* `PermissionChecker`
* `PermissionAllowed`

Michal, have a look please when you get a chance, for the Permission related API, I just tried to avoid some really technical content, references to the examples in some previous methods, and some other minor cleanup. I can tune it as needed if you find I've got some important messages lost during this update.