### PR TITLE
Update upload-artifact action version to 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           echo -n ${{ github.event.number }} > pull-request-number
       - name: Upload pull request number
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pull-request-number-${{ github.event.number }}
           path: pull-request-number
@@ -47,7 +47,7 @@ jobs:
       - name: Build with Maven
         run: mvn -B clean install
       - name: Upload build reports (if build failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
         with:
           name: "build-reports-Build - JDK ${{ matrix.java }}"


### PR DESCRIPTION
Build of #65 failed due to https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/. 
I haven't updated other action versions, not sure of side-effects (see for example https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)