### PR TITLE
Add CDI event `Security` which allows to register identity providers and augmentors programmatically

### DIFF
--- a/src/main/java/io/quarkus/security/Security.java
+++ b/src/main/java/io/quarkus/security/Security.java
@@ -1,0 +1,49 @@
+package io.quarkus.security;
+
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * A CDI event that facilitates programmatic security setup.
+ * The event can be observed with a synchronous observer method like in the example below:
+ *
+ * <pre>
+ * {@code
+ * import io.quarkus.security.identity.IdentityProvider;
+ * import io.quarkus.security.identity.SecurityIdentityAugmentor;
+ * import io.quarkus.security.identity.request.TokenAuthenticationRequest;
+ * import jakarta.enterprise.event.Observes;
+ *
+ * public class SecurityConfiguration {
+ *
+ *     void observe(@Observes Security security) {
+ *         SecurityIdentityAugmentor augmentor = createCustomIdentityAugmentor();
+ *         IdentityProvider<TokenAuthenticationRequest> identityProvider = createCustomIdentityProvider();
+ *         security.identityAugmentor(augmentor).identityProvider(identityProvider);
+ *     }
+ *
+ * }
+ * }
+ * </pre>
+ */
+@Experimental("This API is currently experimental and might get changed")
+public interface Security {
+
+    /**
+     * Registers given {@link IdentityProvider}.
+     *
+     * @param identityProvider {@link IdentityProvider}
+     * @return Security
+     */
+    Security identityProvider(IdentityProvider<?> identityProvider);
+
+    /**
+     * Registers given {@link SecurityIdentityAugmentor}.
+     *
+     * @param securityIdentityAugmentor {@link SecurityIdentityAugmentor}
+     * @return Security
+     */
+    Security identityAugmentor(SecurityIdentityAugmentor securityIdentityAugmentor);
+
+}


### PR DESCRIPTION
This PR introduces experimental `Security` CDI event, which will allow us to provide a fluent API for creating identity providers and augmentors. Currently we allow to register HTTP Auth mechanisms like `httpSecurity.mechanism(new CustomMech());` and having to register the identity provider and augmentor separately (e.g. declare them as CDI beans) breaks our story of programmatic set up.

It will work with both HTTP Security and as a standalone event (users can observe what they want). We already have the `HttpSecurity` API in the Vert.x HTTP extension. We will extend this interface and override methods so that users can use the fluent API without casting this instance, e.g. `httpSecurity.identityAugmentor(new Augmentor()).basic();`.

```
public interface HttpSecurity extends Security {

    @Override
    HttpSecurity identityProvider(IdentityProvider<?> identityProvider);

    @Override
    HttpSecurity identityAugmentor(SecurityIdentityAugmentor securityIdentityAugmentor);
}
```
