### PR TITLE
Fix scm.url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <scm>
         <connection>scm:git:git@github.com:quarkusio/quarkus-security.git</connection>
         <developerConnection>scm:git:git@github.com:quarkusio/quarkus-security.git</developerConnection>
-        <url>https://github.com/quarkus/quarkus-security</url>
+        <url>https://github.com/quarkusio/quarkus-security</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
Hi! This PR corrects the project URL to point to the GitHub source repository, a step for supporting [reproducible builds](https://reproducible-builds.org/) and enhancing software supply chain transparency. A valid URL enables automated verifiers to fetch the source, rebuild the project, and confirm the resulting binary is bit-for-bit identical to the distributed artifact. This verification process ensures our software has not been tampered with and strengthens the chain of trust with our users. See more https://github.com/google/oss-rebuild/blob/main/docs/trust.md.

