### PR TITLE
Add RunAsUser annotation

### DIFF
--- a/src/main/java/io/quarkus/security/identity/RunAsUser.java
+++ b/src/main/java/io/quarkus/security/identity/RunAsUser.java
@@ -1,0 +1,32 @@
+package io.quarkus.security.identity;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.security.Principal;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Identifies a method that must be run with a new {@link SecurityIdentity} that is valid only
+ * for the duration of this method's execution.
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface RunAsUser {
+
+    /**
+     * Configures {@link Principal#getName()} as retrieved by the new identity method {@link SecurityIdentity#getPrincipal()}.
+     *
+     * @return The username used as the new identity principal name.
+     */
+    String user();
+
+    /**
+     * Configures {@link SecurityIdentity#getRoles()} on the new {@link SecurityIdentity}.
+     *
+     * @return The new identity roles.
+     */
+    String[] roles() default {};
+
+}


### PR DESCRIPTION
Adds annotation we need to resolve the https://github.com/quarkusio/quarkus/issues/50803 issue. Intended use is on scheduled methods for now. I intentionally didn't go into details in how this will work, because behavior will most likely involve. For example, when used only on the scheduled methods, we cannot speak of `SecurityIdentity` temporary replacements, which may be a case in other, not yet supported, scenarios.