### PR TITLE
Do not support attributes on AnonymousAuthenticationRequest

### DIFF
--- a/src/main/java/io/quarkus/security/identity/request/AnonymousAuthenticationRequest.java
+++ b/src/main/java/io/quarkus/security/identity/request/AnonymousAuthenticationRequest.java
@@ -1,5 +1,7 @@
 package io.quarkus.security.identity.request;
 
+import java.util.Map;
+
 /**
  * A request the for the Anonymous identity
  */
@@ -7,4 +9,13 @@ public final class AnonymousAuthenticationRequest extends BaseAuthenticationRequ
 
     public static final AnonymousAuthenticationRequest INSTANCE = new AnonymousAuthenticationRequest();
 
+    @Override
+    public void setAttribute(String name, Object value) {
+        throw new UnsupportedOperationException("Attributes are not supported on AnonymousAuthenticationRequest");
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Map.of();
+    }
 }


### PR DESCRIPTION
We will use the shared static INSTANCE so we don't want to write anything to the attributes.

Not sure it's the right fix but it shows the issue. Let's discuss if it's the right thing to do, or if we should just get rid of the static instance.